### PR TITLE
provide glyphs as SVG 

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ This will create a TEI file based on the template charDecl.xml.template with cha
 
 This will create png images from the Bravura font through a small program written by [Alexander Erhard](https://github.com/aerhard).
 
+### Target `glyph2svg`
+
+This will extract individual svg paths from the Bravura font.
+
 ### Target `xar`
 
 This will create all the above and bundle it as an eXist app package.

--- a/bravura2svg.xsl
+++ b/bravura2svg.xsl
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:svg="http://www.w3.org/2000/svg"
+    xmlns:tei="http://www.tei-c.org/ns/1.0"
+    exclude-result-prefixes="xs"
+    version="3.1">
+    
+    <xsl:param name="charDeclPath" as="xs:string" select="'dist/data/charDecl.xml'"/>
+    <xsl:param name="bravuraMetadataPath" as="xs:string" select="'node_modules/bravura/redist/bravura_metadata.json'"/>
+    
+    <xsl:output indent="yes" method="xml" encoding="UTF-8"/>
+    
+    <xsl:variable name="charDecl" as="document-node()?">
+        <xsl:if test="doc-available($charDeclPath)">
+            <xsl:sequence select="doc($charDeclPath)"/>
+        </xsl:if>
+    </xsl:variable>
+    
+    
+    <xsl:variable name="bravuraMetadata" as="map(*)?" select="json-doc($bravuraMetadataPath)"/>
+    
+    <xsl:template match="/">
+        <xsl:apply-templates select=".//svg:glyph[starts-with(@glyph-name, 'uni')]"/>
+    </xsl:template>
+    
+    <xsl:template match="svg:glyph">
+        <!-- Extract the Unicode Codepoint from the @glyph-name attribute, e.g. "uniE050" -->
+        <xsl:variable name="codePoint" select="substring-after(@glyph-name, 'uni')" as="xs:string"/>
+        <!-- Lookup the glyph name by codepoint from our TEI file charDecl.xml -->
+        <xsl:variable name="glyphName" select="$charDecl//tei:mapping[@type='smufl'][substring-after(., 'U+') eq $codePoint]/preceding-sibling::tei:charName => data()" as="xs:string?"/>
+        <!-- Lookup the bounding box from the Bravura metadata JSON file by glyphName -->
+        <xsl:variable name="glyphBBox" select="$bravuraMetadata?glyphBBoxes?($glyphName)" as="map(*)?"/>
+        
+        <!-- IFF the bounding box exists create a file for this glyph -->
+        <xsl:if test="exists($glyphBBox)">
+            <xsl:variable name="offset" select="(($glyphBBox?bBoxSW(1) * 250) => format-number('##'), ($glyphBBox?bBoxNE(2) * 250) => format-number('##'))" as="xs:string+"/>
+            <xsl:result-document href="{$codePoint}.svg">
+                <xsl:text>&#10;</xsl:text>
+                <xsl:text disable-output-escaping='yes'>&lt;!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" &gt;</xsl:text>
+                <xsl:text>&#10;</xsl:text>
+                <xsl:element name="svg" namespace="http://www.w3.org/2000/svg">
+                    <xsl:attribute name="version">1.1</xsl:attribute>
+                    <xsl:attribute name="width" select="(($glyphBBox?bBoxNE(1) - $glyphBBox?bBoxSW(1)) * 250) => format-number('##.###')"/>
+                    <xsl:attribute name="height" select="(($glyphBBox?bBoxNE(2) - $glyphBBox?bBoxSW(2)) * 250) => format-number('##.###')"/>
+                    <xsl:comment select="$glyphName"/>
+                    <xsl:element name="path" namespace="http://www.w3.org/2000/svg">
+                        <xsl:copy select="@d"/>
+                        <xsl:attribute name="transform" select="'translate(' || string-join($offset, ', ') || ') scale(1,-1)'"/>
+                    </xsl:element>
+                </xsl:element>
+            </xsl:result-document>
+        </xsl:if>
+    </xsl:template>
+    
+</xsl:stylesheet>

--- a/bravura2svg.xsl
+++ b/bravura2svg.xsl
@@ -28,7 +28,7 @@
         <!-- Extract the Unicode Codepoint from the @glyph-name attribute, e.g. "uniE050" -->
         <xsl:variable name="codePoint" select="substring-after(@glyph-name, 'uni')" as="xs:string"/>
         <!-- Lookup the glyph name by codepoint from our TEI file charDecl.xml -->
-        <xsl:variable name="glyphName" select="$charDecl//tei:mapping[@type='smufl'][substring-after(., 'U+') eq $codePoint]/preceding-sibling::tei:charName => data()" as="xs:string?"/>
+        <xsl:variable name="glyphName" select="$charDecl//tei:mapping[@type='smufl'][substring(., 3) eq $codePoint]/preceding-sibling::tei:charName => data()" as="xs:string?"/>
         <!-- Lookup the bounding box from the Bravura metadata JSON file by glyphName -->
         <xsl:variable name="glyphBBox" select="$bravuraMetadata?glyphBBoxes?($glyphName)" as="map(*)?"/>
         

--- a/build.xml
+++ b/build.xml
@@ -110,7 +110,7 @@
 	<target name="glyph2svg" depends="charDecl">
 		<description>Extract individual SVG shapes from the SVG font</description>
 		<mkdir dir="${tmp.dir}/svg-glyphs"/>
-		<xslt processor="trax" style="bravura2svg.xsl" basedir="node_modules/bravura/redist/svg" includes="BravuraText.svg" destdir="${tmp.dir}/svg-glyphs">
+		<xslt processor="trax" style="bravura2svg.xsl" basedir="node_modules/bravura/redist/svg" includes="Bravura.svg" destdir="${tmp.dir}/svg-glyphs">
 			<param name="charDeclPath" expression="${dist.dir}/data/charDecl.xml"/>
 			<param name="bravuraMetadataPath" expression="node_modules/bravura/redist/bravura_metadata.json"/>
 		</xslt>

--- a/build.xml
+++ b/build.xml
@@ -107,6 +107,15 @@
 		</java>
 	</target>
 	
+	<target name="glyph2svg" depends="charDecl">
+		<description>Extract individual SVG shapes from the SVG font</description>
+		<mkdir dir="${tmp.dir}/svg-glyphs"/>
+		<xslt processor="trax" style="bravura2svg.xsl" basedir="node_modules/bravura/redist/svg" includes="BravuraText.svg" destdir="${tmp.dir}/svg-glyphs">
+			<param name="charDeclPath" expression="${dist.dir}/data/charDecl.xml"/>
+			<param name="bravuraMetadataPath" expression="node_modules/bravura/redist/bravura_metadata.json"/>
+		</xslt>
+	</target>
+	
 	<target name="charDecl" depends="init, yarn">
 		<description>Merge SMuFL metadata to one TEI file</description>
 		<mkdir dir="${dist.dir}/data"/>
@@ -121,7 +130,7 @@
 		</xslt>
 	</target>
 	
-	<target name="dist" depends="init, yarn, charDecl, otf2png">
+	<target name="dist" depends="init, yarn, charDecl, otf2png, glyph2svg">
 		<copy file="expath-pkg.xml.template" tofile="${dist.dir}/expath-pkg.xml" filtering="true" overwrite="true">
 			<filterset>
 				<filter token="project.version" value="${project.version}"/>
@@ -153,6 +162,9 @@
 		<copy todir="${dist.dir}/resources/images">
 			<fileset dir="${tmp.dir}/png-glyphs">
 				<include name="**/*.png"/>
+			</fileset>
+			<fileset dir="${tmp.dir}/svg-glyphs">
+				<include name="**/*.svg"/>
 			</fileset>
 		</copy>
 		<copy todir="${dist.dir}/resources/fonts">

--- a/templates/about.html
+++ b/templates/about.html
@@ -104,6 +104,20 @@
                             </ul>
                         </div>
                     </dd>
+                    <dt>SVG</dt>
+                    <dd>The webservice will send an SVG file of the glyph shape when queried for the suffix <code>.svg</code>.
+                        Alternatively you can omit the file extension and provide the <i>Content-Type</i> request header <code>image/svg+xml</code>.
+                        <div class="panel panel-info">
+                            <div class="panel-heading">
+                                <h4 class="panel-title">Examples</h4>
+                            </div>
+                            
+                            <ul class="list-group">
+                                <li class="list-group-item"><a href="https://smufl-browser.edirom.de/note8thUp.svg" title="SVG example URL">https://smufl-browser.edirom.de/note8thUp.svg</a></li>
+                                <li class="list-group-item"><a href="https://smufl-browser.edirom.de/E1D7.svg" title="SVG example URL">https://smufl-browser.edirom.de/E1D7.svg</a></li>
+                            </ul>
+                        </div>
+                    </dd>
                     <dt>Multiple characters</dt>
                     <dd>If you want to receive a list of several character definitions, you can query <code>https://smufl-browser.edirom.de/index</code> with the suffixes <code>.tei</code> or <code>.xml</code> (or the respective request headers, see above). 
                         JSON and JSONP are <i>not</i> supported at present.
@@ -119,9 +133,9 @@
                             </div>
                             
                             <ul class="list-group">
-                                <li class="list-group-item"><a href="https://smufl-browser.edirom.de/index.tei" title="complete charDecl">https://smufl-browser.edirom.de/index.tei</a> – this will give you the complete SMuFL specification as TEI file</li>
-                                <li class="list-group-item"><a href="https://smufl-browser.edirom.de/index.xml?range=Rests">https://smufl-browser.edirom.de/index.xml?range=Rests</a></li>
-                                <li class="list-group-item"><a href="https://smufl-browser.edirom.de/index.tei?class=noteheadSetRoundLarge&amp;class=noteheadSetCircled" title="PNG example URL">https://smufl-browser.edirom.de/index.tei?class=noteheadSetRoundLarge&amp;class=noteheadSetCircled</a></li>
+                                <li class="list-group-item"><a href="https://smufl-browser.edirom.de/index.tei" title="Request for the complete charDecl">https://smufl-browser.edirom.de/index.tei</a> – this will give you the complete SMuFL specification as TEI file</li>
+                                <li class="list-group-item"><a href="https://smufl-browser.edirom.de/index.xml?range=Rests" title="Request for a charDecl consisting of the range 'rests' only">https://smufl-browser.edirom.de/index.xml?range=Rests</a></li>
+                                <li class="list-group-item"><a href="https://smufl-browser.edirom.de/index.tei?class=noteheadSetRoundLarge&amp;class=noteheadSetCircled" title="Request for a charDecl consisting of two different classes">https://smufl-browser.edirom.de/index.tei?class=noteheadSetRoundLarge&amp;class=noteheadSetCircled</a></li>
                             </ul>
                         </div>
                     </dd>


### PR DESCRIPTION
This implements #7 by 

1. extracting individual SVG shapes from the Bravura SVG font at build time
2. providing access to these glyphs analogous to PNG images through the web app