### PR TITLE
Redirect the W3C SVG 1.1 DTD

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -120,6 +120,11 @@
 		<xslt processor="trax" style="bravura2svg.xsl" basedir="node_modules/bravura/redist/svg" includes="Bravura.svg" destdir="${tmp.dir}/svg-glyphs">
 			<param name="charDeclPath" expression="${dist.dir}/data/charDecl.xml"/>
 			<param name="bravuraMetadataPath" expression="node_modules/bravura/redist/bravura_metadata.json"/>
+			<!-- Redirect the W3C SVG 1.1 DTD to a local empty stub to avoid JAXP
+			     entity size limit errors on JDK 15+ (jdk.xml.maxParameterEntitySizeLimit). -->
+			<xmlcatalog>
+				<dtd publicId="-//W3C//DTD SVG 1.1//EN" location="tools/svg11-empty.dtd"/>
+			</xmlcatalog>
 		</xslt>
 	</target>
 	

--- a/tools/svg11-empty.dtd
+++ b/tools/svg11-empty.dtd
@@ -1,0 +1,3 @@
+<!-- Empty stub DTD for SVG 1.1. Replaces the W3C remote DTD via xmlcatalog
+     to avoid JAXP entity size limit errors (jdk.xml.maxParameterEntitySizeLimit)
+     when parsing Bravura.svg with newer JDK versions (15+). -->


### PR DESCRIPTION
This pull request addresses issues with XML parsing of SVG files when using newer JDK versions (15+), specifically by preventing entity size limit errors related to the SVG 1.1 DTD. The solution involves redirecting the DTD reference to a local empty stub.

**SVG build process reliability improvements:**

* Updated the `xslt` task in `build.xml` to use an `xmlcatalog` entry, redirecting the W3C SVG 1.1 DTD to a local empty stub (`tools/svg11-empty.dtd`) to avoid JAXP entity size limit errors on JDK 15+ during SVG processing.
* Added `tools/svg11-empty.dtd`, an empty stub DTD for SVG 1.1, providing a local replacement for the remote DTD to support the above redirection.