### PR TITLE
charDecl.xml not valid against current TEI schema

### DIFF
--- a/bravura2svg.xsl
+++ b/bravura2svg.xsl
@@ -28,7 +28,7 @@
         <!-- Extract the Unicode Codepoint from the @glyph-name attribute, e.g. "uniE050" -->
         <xsl:variable name="codePoint" select="substring-after(@glyph-name, 'uni')" as="xs:string"/>
         <!-- Lookup the glyph name by codepoint from our TEI file charDecl.xml -->
-        <xsl:variable name="glyphName" select="$charDecl//tei:mapping[@type='smufl'][substring(., 3) eq $codePoint]/preceding-sibling::tei:charName => data()" as="xs:string?"/>
+        <xsl:variable name="glyphName" select="$charDecl//tei:mapping[@type='smufl'][substring(., 3) eq $codePoint]/preceding-sibling::tei:localProp/@value => data()" as="xs:string?"/>
         <!-- Lookup the bounding box from the Bravura metadata JSON file by glyphName -->
         <xsl:variable name="glyphBBox" select="$bravuraMetadata?glyphBBoxes?($glyphName)" as="map(*)?"/>
         

--- a/build.properties
+++ b/build.properties
@@ -7,7 +7,7 @@
 project.app=SMuFL-Browser
 
 # SMuFl-Browser version. Is not in alignment with the SMuFL specs version 
-project.version=1.8.0-beta
+project.version=2.0.0-beta
 
 # The location of the build directory
 build.dir=build

--- a/charDecl.xml.template
+++ b/charDecl.xml.template
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.tei-c.org/Vault/P5/4.12.0/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="http://www.tei-c.org/Vault/P5/4.12.0/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
    <teiHeader>
       <fileDesc>

--- a/collection.xconf
+++ b/collection.xconf
@@ -1,10 +1,10 @@
 <collection xmlns="http://exist-db.org/collection-config/1.0">
     <index xmlns:tei="http://www.tei-c.org/ns/1.0">
-        <create qname="tei:charName" type="xs:string"/>
         <create qname="tei:mapping" type="xs:string"/>
         <create qname="tei:item" type="xs:string"/>
         <create qname="tei:desc" type="xs:string"/>
         <create qname="@type" type="xs:string"/>
+        <create qname="@value" type="xs:string"/>
         <fulltext default="none" attributes="false"/>
     </index>
 </collection>

--- a/modules/app.xql
+++ b/modules/app.xql
@@ -34,7 +34,7 @@ declare function app:charDesc($node as node(), $model as map(*)) as element(dl) 
     let $char := map:get($model, 'char')
     return 
         <dl class="charDesc">
-            <dt>Character name</dt>
+            <dt>Character entity name</dt>
             <dd>{normalize-space($char/tei:localProp/@value)}</dd>
             <dt>Character description</dt>
             <dd>{normalize-space($char/tei:desc)}</dd>

--- a/modules/app.xql
+++ b/modules/app.xql
@@ -27,7 +27,7 @@ declare function app:test($node as node(), $model as map(*)) {
 };
 
 declare function app:charID($node as node(), $model as map(*)) as element(h1) {
-    <h1>{map:get($model, 'char')/normalize-space(tei:charName)}</h1>
+    <h1>{map:get($model, 'char')/normalize-space(tei:localProp/@value)}</h1>
 };
 
 declare function app:charDesc($node as node(), $model as map(*)) as element(dl) {
@@ -35,7 +35,7 @@ declare function app:charDesc($node as node(), $model as map(*)) as element(dl) 
     return 
         <dl class="charDesc">
             <dt>Character name</dt>
-            <dd>{normalize-space($char/tei:charName)}</dd>
+            <dd>{normalize-space($char/tei:localProp/@value)}</dd>
             <dt>Character description</dt>
             <dd>{normalize-space($char/tei:desc)}</dd>
             <dt>SMuFL codepoint</dt>
@@ -51,7 +51,7 @@ declare function app:charDesc($node as node(), $model as map(*)) as element(dl) 
             <dt>Classes</dt>
             <dd>{if($char//tei:item) then string-join($char//tei:item/normalize-space(), ', ') else 'n.a.'}</dd>
             <dt>TEI code for embedding</dt>
-            <dd><code>&lt;g ref="{string-join(($config:server-url, normalize-space($char/tei:charName) || '.xml'), '/')}"/&gt;</code></dd>
+            <dd><code>&lt;g ref="{string-join(($config:server-url, normalize-space($char/tei:localProp/@value) || '.xml'), '/')}"/&gt;</code></dd>
         </dl>
 };
 
@@ -82,7 +82,7 @@ declare
     %templates:default("glyphname", "all")
     function app:glyphnames-list($node as node(), $model as map(*), $glyphname as xs:string*) as element(option)* {
         for $glyph in $config:charDecl//tei:char
-        let $name := normalize-space($glyph/tei:charName)
+        let $name := normalize-space($glyph/tei:localProp/@value)
         order by $name ascending
         return 
             <option value="{$name}">{
@@ -117,7 +117,7 @@ declare
             if(($range,$class,$glyphname) != 'all') then (
                 $config:charDecl//tei:item[. = $class]/ancestor::tei:char | 
                 $config:charDecl//tei:desc[. = $range]/following-sibling::tei:char[@xml:id] |
-                $config:charDecl//tei:charName[. = $glyphname]/parent::tei:char
+                $config:charDecl//tei:localProp[@value = $glyphname]/parent::tei:char
             )
             else $config:charDecl//tei:char[@xml:id]
         return 

--- a/modules/app.xql
+++ b/modules/app.xql
@@ -81,13 +81,18 @@ declare
     %templates:wrap
     %templates:default("glyphname", "all")
     function app:glyphnames-list($node as node(), $model as map(*), $glyphname as xs:string*) as element(option)* {
-        for $glyph in $config:charDecl//tei:char
+        for $glyph in $config:charDecl//tei:char[tei:localProp/@value = $glyphname]
+        let $name := normalize-space($glyph/tei:localProp/@value)
+        order by $name ascending
+        return 
+            <option value="{$name}" selected="selected">{
+                $name
+            }</option>,
+        for $glyph in $config:charDecl//tei:char[tei:localProp/@value != $glyphname]
         let $name := normalize-space($glyph/tei:localProp/@value)
         order by $name ascending
         return 
             <option value="{$name}">{
-                if($glyphname = $name) then attribute {'selected'} {'selected'} 
-                else (),
                 $name
             }</option>
 };

--- a/modules/config.xqm
+++ b/modules/config.xqm
@@ -126,7 +126,7 @@ declare function config:get-char-by-id($id as xs:string?) as element(tei:char)? 
  : @return the corresponding tei:char element if successful, the empty sequence otherwise
 ~:)
 declare function config:get-char-by-name($name as xs:string?) as element(tei:char)? {
-    $config:charDecl//tei:localProp[@value= $name]/parent::tei:char
+    $config:charDecl//tei:localProp[@value = $name]/parent::tei:char
 };
 
 (:~

--- a/modules/config.xqm
+++ b/modules/config.xqm
@@ -112,8 +112,8 @@ declare function config:app-info($node as node(), $model as map(*)) {
  : Lookup char by xml:id
  : 
  : @param $name the xml:id of a SMuFl character, e.g. '_accidentalBakiyeSharp'
- : The xml:id is identical to the charName with a prefixed underscore
- : @return the corresponding tei:char element if succesful, the empty sequence otherwise
+ : The `xml:id` is identical to the `localProp/@value` with a prefixed underscore
+ : @return the corresponding tei:char element if successful, the empty sequence otherwise
 ~:)
 declare function config:get-char-by-id($id as xs:string?) as element(tei:char)? {
     $config:charDecl//id($id)
@@ -123,10 +123,10 @@ declare function config:get-char-by-id($id as xs:string?) as element(tei:char)? 
  : Lookup char by name
  : 
  : @param $name the name of a SMuFl character, e.g. 'accidentalBakiyeSharp'
- : @return the corresponding tei:char element if succesful, the empty sequence otherwise
+ : @return the corresponding tei:char element if successful, the empty sequence otherwise
 ~:)
 declare function config:get-char-by-name($name as xs:string?) as element(tei:char)? {
-    $config:charDecl//tei:charName[.= $name]/parent::tei:char
+    $config:charDecl//tei:localProp[@value= $name]/parent::tei:char
 };
 
 (:~

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smufl-browser",
-  "version": "1.8.0-beta",
+  "version": "2.0.0-beta",
   "description": "A web based browser for the Standard Music Font Layout",
   "repository": "https://github.com/Edirom/SMuFL-Browser.git",
   "author": "Peter Stadler <stadlerpeter@yahoo.fr>",

--- a/smufl2tei.xsl
+++ b/smufl2tei.xsl
@@ -82,7 +82,7 @@
             <!-- glyph names with a leading digit get an underscore prefix -->
             <xsl:attribute name="xml:id" select="concat('_', $glyphName)"/>
             <xsl:element name="localProp">
-                <xsl:attribute name="name">Name</xsl:attribute>
+                <xsl:attribute name="name">entity</xsl:attribute>
                 <xsl:attribute name="value" select="$glyphName"/>
             </xsl:element>
             <xsl:element name="desc">

--- a/smufl2tei.xsl
+++ b/smufl2tei.xsl
@@ -81,8 +81,9 @@
         <xsl:element name="char">
             <!-- glyph names with a leading digit get an underscore prefix -->
             <xsl:attribute name="xml:id" select="concat('_', $glyphName)"/>
-            <xsl:element name="charName">
-                <xsl:value-of select="$glyphName"/>
+            <xsl:element name="localProp">
+                <xsl:attribute name="name">Name</xsl:attribute>
+                <xsl:attribute name="value" select="$glyphName"/>
             </xsl:element>
             <xsl:element name="desc">
                 <xsl:value-of select="$glyph?description => normalize-space()"/>


### PR DESCRIPTION
The TEI Guidelines removed `<charName>` in [version 4.4.0](https://www.tei-c.org/release/doc/tei-p5-doc/readme-4.4.0.html) and introduced the element `<localProp>`, for "locally defined properties".

This PR updates the processing and output formats to replace the old notation e.g. `<charName>restMaxima</charName>` with `<localProp name="entity" value="restMaxima"/>`. 

NB, this will also change the JSON output from e.g. `{"charName" : "restMaxima"}` to 
`{"localProp" : {"@name": "entity", "@value": "restMaxima"}}`.